### PR TITLE
Add `DOCK SET PROGRESS` draw some progress ui element on dock icon

### DIFF
--- a/Dock Tile/4DPlugin-Dock-Tile.h
+++ b/Dock Tile/4DPlugin-Dock-Tile.h
@@ -25,5 +25,23 @@ void DOCK_SET_ICON(PA_PluginParameters params);
 void DOCK_Get_icon(PA_PluginParameters params);
 void DOCK_GET_SIZE(PA_PluginParameters params);
 void DOCK_GET_SCREEN_FRAME(PA_PluginParameters params);
+void DOCK_SET_PROGRESS(PA_PluginParameters params);
+
+// draw progress
+
+typedef NS_ENUM(NSUInteger, DockIconProgressType) {
+    DockIconProgressBar = 0,
+    DockIconProgressCircle = 1,
+    DockIconProgressSquircle = 2
+};
+typedef struct DrawOptions {
+    DockIconProgressType type = DockIconProgressBar;
+    CGFloat lineWidth = 0;
+    CGFloat radius = 0;
+    CGFloat inset = 0;
+    NSColor* color = NSColor.whiteColor;
+} DrawOptions;
+
+NSImage* draw(NSImage* appIcon, CGFloat progress, DrawOptions options);
 
 #endif /* PLUGIN_DOCK_TILE_H */

--- a/Dock Tile/4DPlugin-JSON.cpp
+++ b/Dock Tile/4DPlugin-JSON.cpp
@@ -1,0 +1,522 @@
+#include "4DPlugin-JSON.h"
+
+void json_wconv(const wchar_t *value, CUTF16String *u16) {
+    
+    size_t wlen = wcslen(value);
+    
+#if VERSIONWIN
+    *u16 = CUTF16String((const PA_Unichar *)value, wlen);
+#else
+    CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8 *)value, wlen*sizeof(wchar_t), kCFStringEncodingUTF32LE, true);
+    if(str)
+    {
+        CFIndex len = CFStringGetLength(str);
+        std::vector<uint8_t> buf((len+1) * sizeof(PA_Unichar));
+        CFStringGetCharacters(str, CFRangeMake(0, len), (UniChar *)&buf[0]);
+        *u16 = CUTF16String((const PA_Unichar *)&buf[0], len);
+        CFRelease(str);
+    }
+#endif
+}
+
+void ob_set_p(PA_ObjectRef obj, const wchar_t *_key, PA_Picture value) {
+    
+    if(obj)
+    {
+        if(value)
+        {
+            PA_Variable v = PA_CreateVariable(eVK_Picture);
+            CUTF16String ukey;
+            json_wconv(_key, &ukey);
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            
+            PA_SetPictureVariable(&v, value);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+        }
+    }
+}
+
+void ob_set_s(PA_ObjectRef obj, const char *_key, const char *_value) {
+
+    if(obj)
+    {
+        CUTF8String u8k = CUTF8String((const uint8_t *)_key);
+        CUTF8String u8v = CUTF8String((const uint8_t *)_value);
+        CUTF16String u16k, u16v;
+        
+#ifdef _WIN32
+        int len = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8k.c_str(), u8k.length(), NULL, 0);
+        if(len){
+            std::vector<uint8_t> buf((len + 1) * sizeof(PA_Unichar));
+            if(MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8k.c_str(), u8k.length(), (LPWSTR)&buf[0], len)){
+                u16k = CUTF16String((const PA_Unichar *)&buf[0]);
+            }
+        }
+        u8v = CUTF8String((const uint8_t *)_value);
+        len = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8v.c_str(), u8v.length(), NULL, 0);
+        if(len){
+            std::vector<uint8_t> buf((len + 1) * sizeof(PA_Unichar));
+            if(MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8v.c_str(), u8v.length(), (LPWSTR)&buf[0], len)){
+                u16v = CUTF16String((const PA_Unichar *)&buf[0]);
+            }
+        }
+#else
+        
+        CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, u8k.c_str(), u8k.length(), kCFStringEncodingUTF8, true);
+        if(str){
+            CFIndex len = CFStringGetLength(str);
+            std::vector<uint8_t> buf((len+1) * sizeof(PA_Unichar));
+            CFStringGetCharacters(str, CFRangeMake(0, len), (UniChar *)&buf[0]);
+            u16k = CUTF16String((const PA_Unichar *)&buf[0]);
+            CFRelease(str);
+        }
+        str = CFStringCreateWithBytes(kCFAllocatorDefault, u8v.c_str(), u8v.length(), kCFStringEncodingUTF8, true);
+        if(str){
+            CFIndex len = CFStringGetLength(str);
+            std::vector<uint8_t> buf((len+1) * sizeof(PA_Unichar));
+            CFStringGetCharacters(str, CFRangeMake(0, len), (UniChar *)&buf[0]);
+            u16v = CUTF16String((const PA_Unichar *)&buf[0]);
+            CFRelease(str);
+        }
+#endif
+        
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)u16k.c_str());
+        PA_Unistring value = PA_CreateUnistring((PA_Unichar *)u16v.c_str());
+        
+        PA_Variable v = PA_CreateVariable(eVK_Unistring);
+        PA_SetStringVariable(&v, &value);
+        PA_SetObjectProperty(obj, &key, v);
+        
+        PA_DisposeUnistring(&key);
+        PA_ClearVariable(&v);
+        
+    }
+
+}
+
+void ob_set_s(PA_ObjectRef obj, const wchar_t *_key, const char *_value) {
+    
+    if(obj)
+    {
+        if(_value)
+        {
+            PA_Variable v = PA_CreateVariable(eVK_Unistring);
+            CUTF16String ukey;
+            
+            json_wconv(_key, &ukey);
+            
+            CUTF8String u8 = CUTF8String((const uint8_t *)_value);
+            CUTF16String u16;
+            
+#ifdef _WIN32
+            int len = MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8.c_str(), u8.length(), NULL, 0);
+            
+            if(len){
+                std::vector<uint8_t> buf((len + 1) * sizeof(PA_Unichar));
+                if(MultiByteToWideChar(CP_UTF8, 0, (LPCSTR)u8.c_str(), u8.length(), (LPWSTR)&buf[0], len)){
+                    u16 = CUTF16String((const PA_Unichar *)&buf[0]);
+                }
+            }else{
+                u16 = CUTF16String((const PA_Unichar *)L"");
+            }
+            
+#else
+            CFStringRef str = CFStringCreateWithBytes(kCFAllocatorDefault, u8.c_str(), u8.length(), kCFStringEncodingUTF8, true);
+            if(str){
+                CFIndex len = CFStringGetLength(str);
+                std::vector<uint8_t> buf((len+1) * sizeof(PA_Unichar));
+                CFStringGetCharacters(str, CFRangeMake(0, len), (UniChar *)&buf[0]);
+                u16 = CUTF16String((const PA_Unichar *)&buf[0]);
+                CFRelease(str);
+            }
+#endif
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            PA_Unistring value = PA_CreateUnistring((PA_Unichar *)u16.c_str());
+            
+            PA_SetStringVariable(&v, &value);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+        }
+    }
+}
+
+void ob_set_a(PA_ObjectRef obj, const wchar_t *_key, CUTF16String *value) {
+    
+    if(obj)
+    {
+            PA_Variable v = PA_CreateVariable(eVK_Unistring);
+            CUTF16String ukey;
+            json_wconv(_key, &ukey);
+ 
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            PA_Unistring uvalue = PA_CreateUnistring((PA_Unichar *)value->c_str());
+            
+            PA_SetStringVariable(&v, &uvalue);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+    }
+}
+
+void ob_set_a(PA_ObjectRef obj, const wchar_t *_key, const wchar_t *_value) {
+    
+    if(obj)
+    {
+        if(_value)
+        {
+            PA_Variable v = PA_CreateVariable(eVK_Unistring);
+            CUTF16String ukey;
+            CUTF16String uvalue;
+            json_wconv(_key, &ukey);
+            json_wconv(_value, &uvalue);
+            
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            PA_Unistring value = PA_CreateUnistring((PA_Unichar *)uvalue.c_str());
+            
+            PA_SetStringVariable(&v, &value);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+        }
+    }
+}
+
+void ob_set_o(PA_ObjectRef obj, const wchar_t *_key, PA_ObjectRef value) {
+    
+    if(obj)
+    {
+        if(value)
+        {
+            PA_Variable v = PA_CreateVariable(eVK_Object);
+            CUTF16String ukey;
+            json_wconv(_key, &ukey);
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            
+            PA_SetObjectVariable(&v, value);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+        }
+    }
+}
+
+void ob_set_c(PA_ObjectRef obj, const wchar_t *_key, PA_CollectionRef value) {
+    
+    if(obj)
+    {
+        if(value)
+        {
+            PA_Variable v = PA_CreateVariable(eVK_Collection);
+            CUTF16String ukey;
+            json_wconv(_key, &ukey);
+            PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+            
+            PA_SetCollectionVariable(&v, value);
+            PA_SetObjectProperty(obj, &key, v);
+            
+            PA_DisposeUnistring(&key);
+            PA_ClearVariable(&v);
+        }
+    }
+}
+
+void ob_set_n(PA_ObjectRef obj, const wchar_t *_key, double value) {
+    
+    if(obj)
+    {
+        PA_Variable v = PA_CreateVariable(eVK_Real);
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        PA_SetRealVariable(&v, value);
+        PA_SetObjectProperty(obj, &key, v);
+        
+        PA_DisposeUnistring(&key);
+        PA_ClearVariable(&v);
+    }
+}
+
+void ob_set_i(PA_ObjectRef obj, const wchar_t *_key, PA_long32 value) {
+    
+    if(obj)
+    {
+        PA_Variable v = PA_CreateVariable(eVK_Longint);
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        PA_SetLongintVariable(&v, value);
+        PA_SetObjectProperty(obj, &key, v);
+        
+        PA_DisposeUnistring(&key);
+        PA_ClearVariable(&v);
+    }
+}
+
+void ob_set_b(PA_ObjectRef obj, const wchar_t *_key, bool value) {
+    
+    if(obj)
+    {
+        PA_Variable v = PA_CreateVariable(eVK_Boolean);
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        PA_SetBooleanVariable(&v, value);
+        PA_SetObjectProperty(obj, &key, v);
+        
+        PA_DisposeUnistring(&key);
+        PA_ClearVariable(&v);
+    }
+}
+
+bool ob_is_defined(PA_ObjectRef obj, const wchar_t *_key) {
+    
+    bool is_defined = false;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        is_defined = PA_HasObjectProperty(obj, &key);
+        
+        PA_DisposeUnistring(&key);
+    }
+    return is_defined;
+}
+
+bool ob_get_s(PA_ObjectRef obj, const wchar_t *_key, CUTF8String *value) {
+    
+    bool is_defined = false;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        is_defined = PA_HasObjectProperty(obj, &key);
+        
+        if(is_defined)
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Unistring)
+            {
+                PA_Unistring uvalue = PA_GetStringVariable(v);
+                
+                CUTF16String u = CUTF16String(uvalue.fString, uvalue.fLength);
+#ifdef _WIN32
+                int len = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)u.c_str(), u.length(), NULL, 0, NULL, NULL);
+                
+                if(len){
+                    std::vector<uint8_t> buf(len + 1);
+                    if(WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)u.c_str(), u.length(), (LPSTR)&buf[0], len, NULL, NULL)){
+                        *value = CUTF8String((const uint8_t *)&buf[0]);
+                    }
+                }else{
+                    *value = CUTF8String((const uint8_t *)"");
+                }
+                
+#else
+                CFStringRef str = CFStringCreateWithCharacters(kCFAllocatorDefault, (const UniChar *)u.c_str(), u.length());
+                if(str){
+                    
+                    size_t size = CFStringGetMaximumSizeForEncoding(
+                                                                    CFStringGetLength(str),
+                                                                    kCFStringEncodingUTF8) + sizeof(uint8_t);
+                    std::vector<uint8_t> buf(size);
+                    CFIndex len = 0;
+                    CFStringGetBytes(str,
+                                     CFRangeMake(
+                                                 0,
+                                                 CFStringGetLength(str)),
+                                     kCFStringEncodingUTF8,
+                                     0, true, (UInt8 *)&buf[0], size, &len);
+                    
+                    *value = CUTF8String((const uint8_t *)&buf[0], len);
+                    CFRelease(str);
+                }
+#endif
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    
+    return is_defined;
+}
+
+bool ob_get_a(PA_ObjectRef obj, const wchar_t *_key, CUTF16String *value) {
+    
+    bool is_defined = false;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        is_defined = PA_HasObjectProperty(obj, &key);
+        
+        if(is_defined)
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Unistring)
+            {
+                PA_Unistring uvalue = PA_GetStringVariable(v);
+                *value = CUTF16String(uvalue.fString, uvalue.fLength);
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    
+    return is_defined;
+}
+
+bool ob_get_b(PA_ObjectRef obj, const wchar_t *_key) {
+    
+    bool value = false;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        if(PA_HasObjectProperty(obj, &key))
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Boolean)
+            {
+                value = PA_GetBooleanVariable(v);
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    
+    return value;
+}
+
+double ob_get_n(PA_ObjectRef obj, const wchar_t *_key) {
+    
+    double value = 0.0f;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+
+        if(PA_HasObjectProperty(obj, &key))
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Real)
+            {
+                value = PA_GetRealVariable(v);
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    
+    return value;
+}
+
+PA_ObjectRef ob_get_o(PA_ObjectRef obj, const wchar_t *_key) {
+
+    PA_ObjectRef value = NULL;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        if(PA_HasObjectProperty(obj, &key))
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Object)
+            {
+                value = PA_GetObjectVariable(v);
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    return value;
+}
+
+PA_CollectionRef ob_get_c(PA_ObjectRef obj, const wchar_t *_key) {
+    
+    PA_CollectionRef value = NULL;
+    
+    if(obj)
+    {
+        CUTF16String ukey;
+        json_wconv(_key, &ukey);
+        PA_Unistring key = PA_CreateUnistring((PA_Unichar *)ukey.c_str());
+        
+        if(PA_HasObjectProperty(obj, &key))
+        {
+            PA_Variable v = PA_GetObjectProperty(obj, &key);
+            if(PA_GetVariableKind(v) == eVK_Collection)
+            {
+                value = PA_GetCollectionVariable(v);
+            }
+        }
+        
+        PA_DisposeUnistring(&key);
+    }
+    return value;
+}
+
+void ob_stringify(PA_ObjectRef obj, CUTF8String *value) {
+    
+    PA_Variable    _params[1];
+    _params[0] = PA_CreateVariable(eVK_Object);
+    PA_SetObjectVariable(&_params[0], PA_DuplicateObject(obj));
+    PA_Variable vjson = PA_ExecuteCommandByID( /*JSON Stringify */1217, _params, 1);
+    PA_ClearVariable(&_params[0]);
+    
+    PA_Unistring ujson = PA_GetStringVariable(vjson);
+    
+#ifdef _WIN32
+    int len = WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)ujson.fString, ujson.fLength, NULL, 0, NULL, NULL);
+    
+    if(len){
+        std::vector<uint8_t> buf(len + 1);
+        if(WideCharToMultiByte(CP_UTF8, 0, (LPCWSTR)ujson.fString, ujson.fLength, (LPSTR)&buf[0], len, NULL, NULL)){
+            *value = CUTF8String((const uint8_t *)&buf[0]);
+        }
+    }else{
+        *value = CUTF8String((const uint8_t *)"");
+    }
+    
+#else
+    CFStringRef str = CFStringCreateWithCharacters(kCFAllocatorDefault, (const UniChar *)ujson.fString, ujson.fLength);
+    if(str){
+        
+        size_t size = CFStringGetMaximumSizeForEncoding(CFStringGetLength(str), kCFStringEncodingUTF8) + sizeof(uint8_t);
+        std::vector<uint8_t> buf(size);
+        CFIndex len = 0;
+        CFStringGetBytes(str, CFRangeMake(0, CFStringGetLength(str)), kCFStringEncodingUTF8, 0, true, (UInt8 *)&buf[0], size, &len);
+        
+        *value = CUTF8String((const uint8_t *)&buf[0], len);
+        CFRelease(str);
+    }
+    
+#endif
+    
+    PA_ClearVariable(&vjson);
+}

--- a/Dock Tile/4DPlugin-JSON.h
+++ b/Dock Tile/4DPlugin-JSON.h
@@ -1,0 +1,52 @@
+﻿#ifndef PLUGIN_JSON_H
+#define PLUGIN_JSON_H
+
+#include "4DPluginAPI.h"
+#include <string>
+#include <vector>
+#include <map>
+#include <iostream>     // std::cout
+#include <iterator>     // std::back_inserter
+#include <vector>       // std::vector
+#include <algorithm>    // std::copy
+
+#ifdef __APPLE__
+#include <CoreFoundation/CoreFoundation.h>
+#else
+#include <Windows.h>
+#endif
+
+typedef std::basic_string<PA_Unichar> CUTF16String;
+typedef std::basic_string<uint8_t> CUTF8String;
+
+void json_wconv(const wchar_t *value, CUTF16String *u16);
+
+void ob_set_p(PA_ObjectRef obj, const wchar_t *_key, PA_Picture value);
+
+void ob_set_s(PA_ObjectRef obj, const wchar_t *_key, const char *_value);
+void ob_set_s(PA_ObjectRef obj, const char *_key, const char *_value);
+
+void ob_set_a(PA_ObjectRef obj, const wchar_t *_key, CUTF16String *value);
+void ob_set_a(PA_ObjectRef obj, const wchar_t *_key, const wchar_t *_value);
+
+void ob_set_c(PA_ObjectRef obj, const wchar_t *_key, PA_CollectionRef value);
+void ob_set_o(PA_ObjectRef obj, const wchar_t *_key, PA_ObjectRef value);
+void ob_set_i(PA_ObjectRef obj, const wchar_t *_key, PA_long32 value);
+void ob_set_n(PA_ObjectRef obj, const wchar_t *_key, double value);
+void ob_set_b(PA_ObjectRef obj, const wchar_t *_key, bool value);
+
+bool ob_is_defined(PA_ObjectRef obj, const wchar_t *_key);
+
+bool ob_get_s(PA_ObjectRef obj, const wchar_t *_key, CUTF8String *value);
+
+bool ob_get_a(PA_ObjectRef obj, const wchar_t *_key, CUTF16String *value);
+
+bool ob_get_b(PA_ObjectRef obj, const wchar_t *_key);
+double ob_get_n(PA_ObjectRef obj, const wchar_t *_key);
+
+PA_CollectionRef ob_get_c(PA_ObjectRef obj, const wchar_t *_key);
+PA_ObjectRef ob_get_o(PA_ObjectRef obj, const wchar_t *_key);
+
+void ob_stringify(PA_ObjectRef obj, CUTF8String *value);
+
+#endif /* PLUGIN_JSON_H */

--- a/Dock Tile/Dock Tile.xcodeproj/project.pbxproj
+++ b/Dock Tile/Dock Tile.xcodeproj/project.pbxproj
@@ -13,6 +13,11 @@
 		18B684FA06944F2000CC6A1E /* PrivateTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B684F306944F2000CC6A1E /* PrivateTypes.h */; };
 		18B684FB06944F2000CC6A1E /* PublicTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 18B684F406944F2000CC6A1E /* PublicTypes.h */; };
 		18B684FF06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 18B684FE06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp */; };
+		48B119C026ACBA02009C3433 /* NSBezierPath+DockTile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48B119BE26ACBA02009C3433 /* NSBezierPath+DockTile.cpp */; };
+		48B119C126ACBA02009C3433 /* NSBezierPath+DockTile.h in Headers */ = {isa = PBXBuildFile; fileRef = 48B119BF26ACBA02009C3433 /* NSBezierPath+DockTile.h */; };
+		48B119C426ACBA10009C3433 /* 4DPlugin-JSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48B119C226ACBA0F009C3433 /* 4DPlugin-JSON.cpp */; };
+		48B119C526ACBA10009C3433 /* 4DPlugin-JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */; };
+		48B119C726ACBA46009C3433 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48B119C626ACBA46009C3433 /* QuartzCore.framework */; };
 		8D01CCCA0486CAD60068D4B7 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C167DFE841241C02AAC07 /* InfoPlist.strings */; };
 		D120937F13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h in Headers */ = {isa = PBXBuildFile; fileRef = D120937E13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h */; };
 		D130064F12F02D9700702C0E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D130064E12F02D9700702C0E /* Cocoa.framework */; };
@@ -45,10 +50,15 @@
 		18B684F306944F2000CC6A1E /* PrivateTypes.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = PrivateTypes.h; sourceTree = "<group>"; };
 		18B684F406944F2000CC6A1E /* PublicTypes.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = PublicTypes.h; sourceTree = "<group>"; };
 		18B684FE06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 30; path = "4DPlugin-Dock-Tile.cpp"; sourceTree = "<group>"; };
+		48B119BE26ACBA02009C3433 /* NSBezierPath+DockTile.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = "NSBezierPath+DockTile.cpp"; sourceTree = "<group>"; };
+		48B119BF26ACBA02009C3433 /* NSBezierPath+DockTile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSBezierPath+DockTile.h"; sourceTree = "<group>"; };
+		48B119C226ACBA0F009C3433 /* 4DPlugin-JSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "4DPlugin-JSON.cpp"; sourceTree = "<group>"; };
+		48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "4DPlugin-JSON.h"; sourceTree = "<group>"; };
+		48B119C626ACBA46009C3433 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
 		8D01CCD10486CAD60068D4B7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D120937E13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "4DPlugin-Dock-Tile.h"; sourceTree = "<group>"; };
 		D130064E12F02D9700702C0E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
-		D13116A81A03ACB700DE1322 /* 4DPluginAPI.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = 4DPluginAPI.c; sourceTree = "<group>"; };
+		D13116A81A03ACB700DE1322 /* 4DPluginAPI.c */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp; fileEncoding = 4; path = 4DPluginAPI.c; sourceTree = "<group>"; usesTabs = 0; };
 		D134D4A91A030B06008D14EF /* manifest.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = manifest.json; sourceTree = "<group>"; };
 		D14D10DD1A03A8A5008B3411 /* constants.xlf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xml; path = constants.xlf; sourceTree = "<group>"; };
 		D163219223EBAC2600E1FAFA /* C_TEXT.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = C_TEXT.h; path = "4D Plugin API/Classes/C_TEXT.h"; sourceTree = "<group>"; };
@@ -61,6 +71,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				48B119C726ACBA46009C3433 /* QuartzCore.framework in Frameworks */,
 				D130064F12F02D9700702C0E /* Cocoa.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -106,6 +117,10 @@
 			children = (
 				18B684FE06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp */,
 				D120937E13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h */,
+				48B119C226ACBA0F009C3433 /* 4DPlugin-JSON.cpp */,
+				48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */,
+				48B119BE26ACBA02009C3433 /* NSBezierPath+DockTile.cpp */,
+				48B119BF26ACBA02009C3433 /* NSBezierPath+DockTile.h */,
 				18B684ED06944F2000CC6A1E /* 4D Plugin API */,
 			);
 			name = Source;
@@ -144,6 +159,7 @@
 		D16FBB3C22A4C07E008F0416 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				48B119C626ACBA46009C3433 /* QuartzCore.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -163,6 +179,8 @@
 				18B684FB06944F2000CC6A1E /* PublicTypes.h in Headers */,
 				D163219723EBAC2600E1FAFA /* C_TYPES.h in Headers */,
 				D120937F13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h in Headers */,
+				48B119C126ACBA02009C3433 /* NSBezierPath+DockTile.h in Headers */,
+				48B119C526ACBA10009C3433 /* 4DPlugin-JSON.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -270,6 +288,8 @@
 				18B684FF06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp in Sources */,
 				D163219623EBAC2600E1FAFA /* C_TEXT.cpp in Sources */,
 				D13116A91A03ACB700DE1322 /* 4DPluginAPI.c in Sources */,
+				48B119C426ACBA10009C3433 /* 4DPlugin-JSON.cpp in Sources */,
+				48B119C026ACBA02009C3433 /* NSBezierPath+DockTile.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Dock Tile/NSBezierPath+DockTile.cpp
+++ b/Dock Tile/NSBezierPath+DockTile.cpp
@@ -1,0 +1,151 @@
+//
+//  NSBezierPath+DockTile.cpp
+//  Dock Tile
+//
+//  Created by Eric Marchand on 24/07/2021.
+//
+#import "NSBezierPath+DockTile.h"
+
+@implementation NSBezierPath (CGPath)
+
+- (CGPathRef)quartzPath
+{
+    NSInteger i, numElements;
+ 
+    // Need to begin a path here.
+    CGPathRef           immutablePath = NULL;
+ 
+    // Then draw the path elements.
+    numElements = [self elementCount];
+    if (numElements > 0)
+    {
+        CGMutablePathRef    path = CGPathCreateMutable();
+        NSPoint             points[3];
+        BOOL                didClosePath = YES;
+        
+        for (i = 0; i < numElements; i++)
+        {
+            switch ([self elementAtIndex:i associatedPoints:points])
+            {
+                case NSMoveToBezierPathElement:
+                    CGPathMoveToPoint(path, NULL, points[0].x, points[0].y);
+                    break;
+                    
+                case NSLineToBezierPathElement:
+                    CGPathAddLineToPoint(path, NULL, points[0].x, points[0].y);
+                    didClosePath = NO;
+                    break;
+                    
+                case NSCurveToBezierPathElement:
+                    CGPathAddCurveToPoint(path, NULL, points[0].x, points[0].y,
+                                          points[1].x, points[1].y,
+                                          points[2].x, points[2].y);
+                    didClosePath = NO;
+                    break;
+                    
+                case NSClosePathBezierPathElement:
+                    CGPathCloseSubpath(path);
+                    didClosePath = YES;
+                    break;
+            }
+        }
+        
+        // Be sure the path is closed or Quartz may not do valid hit detection.
+        if (!didClosePath)
+            CGPathCloseSubpath(path);
+        
+        immutablePath = CGPathCreateCopy(path);
+        CGPathRelease(path);
+    }
+ 
+    return immutablePath;
+}
+
+@end
+
+@implementation ProgressCircleShapeLayer
+- (void)setProgress:(CGFloat)progress {
+    self.strokeEnd = CGFloat(progress * 1.02);
+}
+ - (instancetype)initWithRadius:(CGFloat)radius center:(CGPoint)center {
+     if ( !(self = [super init]) )
+     {
+         return nil;
+     }
+     self.fillColor = nil;
+     self.lineCap = @"kCALineCapRound";
+     self.position = center;
+     self.strokeEnd = 0;
+
+     CGFloat startAngle = 90;
+     NSBezierPath* path = [[NSBezierPath alloc] init];
+     [path appendBezierPathWithArcWithCenter:center radius:radius startAngle:startAngle endAngle:startAngle - 360 clockwise:YES];
+     [path closePath];
+
+     CGPathRef pathRef = path.CGPath;
+     self.path = pathRef;
+     self.bounds = CGPathGetBoundingBox(pathRef);
+
+     return self;
+ }
+@end
+
+@implementation ProgressSquircleShapeLayer
+- (void)setProgress:(CGFloat)progress {
+    self.strokeEnd = CGFloat(progress * 1.02);
+}
+ - (instancetype)initWithRect:(CGRect)rect {
+     if ( !(self = [super init]) )
+     {
+         return nil;
+     }
+     self.fillColor = nil;
+     self.lineCap = @"kCALineCapRound";
+     self.position = CGPointZero;
+     self.strokeEnd = 0;
+
+     NSBezierPath* path = [[NSBezierPath alloc] init];
+
+     CGFloat cornerRadius = rect.size.width / 2;
+     CGFloat minSide = fmin(rect.size.width, rect.size.height);
+     CGFloat radius = fmin(CGFloat(cornerRadius), minSide / 2);
+
+     CGPoint center = CGPointMake(CGRectGetMidX(rect), CGRectGetMidY(rect));
+     CGPoint topLeft = CGPointMake(CGRectGetMinX(rect), CGRectGetMinY(rect));
+     CGPoint topRight = CGPointMake(CGRectGetMaxX(rect) ,CGRectGetMinY(rect));
+     CGPoint bottomLeft = CGPointMake(CGRectGetMinX(rect), CGRectGetMaxY(rect));
+     CGPoint bottomRight = CGPointMake(CGRectGetMaxX(rect) ,CGRectGetMaxY(rect));
+     CGPoint point1 = CGPointMake(CGRectGetMinX(rect) + radius, CGRectGetMinY(rect));
+     CGPoint point2 = CGPointMake(CGRectGetMaxX(rect) - radius, CGRectGetMinY(rect));
+     CGPoint point3 = CGPointMake(CGRectGetMaxX(rect), CGRectGetMinY(rect) + radius);
+     CGPoint point4 = CGPointMake(CGRectGetMaxX(rect), CGRectGetMaxY(rect) - radius);
+     CGPoint point5 = CGPointMake(CGRectGetMaxX(rect) - radius, CGRectGetMaxY(rect));
+     CGPoint point6 = CGPointMake(CGRectGetMinX(rect) + radius, CGRectGetMaxY(rect));
+     CGPoint point7 = CGPointMake(CGRectGetMinX(rect) , CGRectGetMaxY(rect) - radius);
+     CGPoint point8 = CGPointMake(CGRectGetMinX(rect) , CGRectGetMinY(rect) + radius);
+
+     [path moveToPoint: point1];
+     [path lineToPoint: point2];
+     [path curveToPoint:point3 controlPoint1:topRight controlPoint2:topRight];
+     [path lineToPoint: point4];
+     [path curveToPoint: point5 controlPoint1: bottomRight controlPoint2: bottomRight];
+     [path lineToPoint: point6];
+     [path curveToPoint: point7 controlPoint1: bottomLeft controlPoint2: bottomLeft];
+     [path lineToPoint: point8];
+     [path curveToPoint: point1 controlPoint1: topLeft controlPoint2: topLeft];
+
+     NSAffineTransform* transform = [[NSAffineTransform alloc] init];
+
+     [transform translateXBy: center.x yBy: center.y];
+     [transform rotateByDegrees: 90];
+     [transform translateXBy: -center.x yBy: -center.y];
+     [path transformUsingAffineTransform: transform];
+     path = [path bezierPathByReversingPath];
+
+     CGPathRef pathRef = path.CGPath;
+     self.path = pathRef;
+     self.bounds = CGPathGetBoundingBox(pathRef);
+
+     return self;
+}
+@end

--- a/Dock Tile/NSBezierPath+DockTile.h
+++ b/Dock Tile/NSBezierPath+DockTile.h
@@ -1,0 +1,37 @@
+//
+//  NSBezierPath+CGPath.hpp
+//  Dock Tile
+//
+//  Created by Eric Marchand on 24/07/2021.
+//
+
+#ifndef DOCK_PATH_H
+#define DOCK_PATH_H
+
+#import <Cocoa/Cocoa.h>
+#import <QuartzCore/QuartzCore.h>
+
+@interface NSBezierPath (CGPath)
+
+@property (readonly, getter=quartzPath) CGPathRef CGPath ;
+
+-(CGPathRef)quartzPath;
+
+@end
+
+@interface ProgressCircleShapeLayer : CAShapeLayer
+
+- (instancetype)initWithRadius:(CGFloat)radius center:(CGPoint)center;
+- (void)setProgress:(CGFloat)progress;
+
+@end
+
+@interface ProgressSquircleShapeLayer : CAShapeLayer
+
+- (instancetype)initWithRect:(CGRect)rect;
+- (void)setProgress:(CGFloat)progress;
+
+@end
+
+
+#endif /* DOCK_PATH_H */

--- a/Dock Tile/manifest.json
+++ b/Dock Tile/manifest.json
@@ -41,6 +41,11 @@
             "theme": "Size",
             "syntax": "DOCK GET SCREEN FRAME(&8;&8;&8;&8)",
             "threadSafe": true
+        },
+        {
+            "theme": "Dock",
+            "syntax": "DOCK SET PROGRESS(&8;&J)",
+            "threadSafe": true
         }
     ]
 }

--- a/Dock Tile/test/Project/DerivedData/formAttributes.json
+++ b/Dock Tile/test/Project/DerivedData/formAttributes.json
@@ -1,3 +1,12 @@
-﻿{
-	"forms": {}
+{
+	"forms": {
+		"フォーム1": {
+			"timeStamp": "2021-07-23T11:24:04.252Z",
+			"destination": "detailScreen"
+		},
+		"プログレス": {
+			"timeStamp": "2021-07-24T08:33:59.920Z",
+			"destination": "detailScreen"
+		}
+	}
 }

--- a/Dock Tile/test/Project/Sources/Forms/プログレス/form.4DForm
+++ b/Dock Tile/test/Project/Sources/Forms/プログレス/form.4DForm
@@ -1,0 +1,50 @@
+{
+	"$4d": {
+		"version": "1",
+		"kind": "form"
+	},
+	"windowSizingX": "variable",
+	"windowSizingY": "variable",
+	"windowMinWidth": 0,
+	"windowMinHeight": 0,
+	"windowMaxWidth": 32767,
+	"windowMaxHeight": 32767,
+	"rightMargin": 20,
+	"bottomMargin": 20,
+	"events": [
+		"onLoad",
+		"onClick",
+		"onTimer"
+	],
+	"windowTitle": "window title",
+	"destination": "detailScreen",
+	"pages": [
+		{
+			"objects": {}
+		},
+		{
+			"objects": {
+				"Button": {
+					"type": "button",
+					"text": "スタート",
+					"top": 23,
+					"left": 22,
+					"width": 116,
+					"height": 56,
+					"events": [
+						"onClick"
+					]
+				}
+			}
+		}
+	],
+	"geometryStamp": 7,
+	"method": "method.4dm",
+	"editor": {
+		"activeView": "View 1",
+		"defaultView": "View 1",
+		"views": {
+			"View 1": {}
+		}
+	}
+}

--- a/Dock Tile/test/Project/Sources/Forms/プログレス/method.4dm
+++ b/Dock Tile/test/Project/Sources/Forms/プログレス/method.4dm
@@ -1,0 +1,47 @@
+
+
+Case of 
+	: (Form event code:C388=On Load:K2:1)
+		
+		Form:C1466.progress:=0
+		Form:C1466.colors:=New collection:C1472(\
+			New object:C1471("red"; 1; "green"; 1; "blue"; 1); \
+			New object:C1471("red"; 1; "green"; 0.3; "blue"; 0.3); \
+			New object:C1471("red"; 0.3; "green"; 1; "blue"; 0.3); \
+			New object:C1471("red"; 0.3; "green"; 0.3; "blue"; 1)\
+			)
+		Form:C1466.colorIndex:=0
+		Form:C1466.options:=New object:C1471("style"; 0; "radius"; 40; "color"; Form:C1466.color[Form:C1466.colorIndex])
+		
+	: (Form event code:C388=On Clicked:K2:4)
+		
+		Form:C1466.activated:=Not:C34(Bool:C1537(Form:C1466.activated))
+		If (Form:C1466.activated)
+			SET TIMER:C645(1)
+		Else 
+			SET TIMER:C645(0)
+			Form:C1466.progress:=0
+			DOCK SET PROGRESS(Form:C1466.progress)
+		End if 
+		
+	: (Form event code:C388=On Timer:K2:25)
+		
+		Form:C1466.progress:=Form:C1466.progress+0.01
+		If (Form:C1466.progress>1)  // loop 0 to 1
+			Form:C1466.progress:=Form:C1466.progress-1
+			Form:C1466.options.style:=Form:C1466.options.style+1
+			If (Form:C1466.options.style>2)  // loop style from 0 to 2
+				Form:C1466.options.style:=0
+				Form:C1466.colorIndex:=Form:C1466.colorIndex+1
+				If (Form:C1466.colorIndex>=Form:C1466.colors.length)
+					Form:C1466.colorIndex:=0
+				End if 
+				Form:C1466.options.color:=Form:C1466.colors[Form:C1466.colorIndex]
+			End if 
+		End if 
+		
+		DOCK SET PROGRESS(Form:C1466.progress; Form:C1466.options)
+		
+	Else 
+		
+End case 


### PR DESCRIPTION
Hi, new method `DOCK SET PROGRESS` to show some activity on app dock icon

 `DOCK SET PROGRESS(progress; params)`

 | Parameter  | Type | Description  | 
 | -- | -- | -- | 
 | progress   |  REAL  |   Value between 0 and 1 of progression  to draw |
 | params  |  OBJECT  |   Object to configure the drawn element |

**params**

 | Property | Type | Description | 
 | -- | -- | -- | 
 | style | Integer  | 0: `bar`, 1: `circle`, 2: `squircle`  | 
 | radius |  Integer | `circle`: radius of the circle (default: 30)   | 
 | lineWidth | Integer |  Line width (default: according to style) | 
 | inset | Integer | `squircle`: add a little inset if the app icon is not standard size | 
 | color | Object  |  The color (default white)  |

**color**

 | Property | Type | Description | 
 | -- | -- | -- | 
 | red | Real  | 0 to 1  | 
 | green | Real  | 0 to 1  | 
 | blue | Real  | 0 to 1  | 
 | alpha | Real  | 0 to 1 (optional, if not defined 1) | 

---

In test database I have made the form プログレス which change dock progress value, style and color
![dockprogress](https://user-images.githubusercontent.com/59135882/126882247-1a75990a-6638-46bd-9ada-b25c0eb8226e.gif)
