### PR TITLE
WIP: 🚧 Prototype to add custom menu to dock

### DIFF
--- a/Dock Tile/4DPlugin-Dock-Tile.h
+++ b/Dock Tile/4DPlugin-Dock-Tile.h
@@ -26,6 +26,7 @@ void DOCK_Get_icon(PA_PluginParameters params);
 void DOCK_GET_SIZE(PA_PluginParameters params);
 void DOCK_GET_SCREEN_FRAME(PA_PluginParameters params);
 void DOCK_SET_PROGRESS(PA_PluginParameters params);
+void DOCK_MENU(PA_PluginParameters params);
 
 // draw progress
 

--- a/Dock Tile/manifest.json
+++ b/Dock Tile/manifest.json
@@ -46,6 +46,11 @@
             "theme": "Dock",
             "syntax": "DOCK SET PROGRESS(&8;&J)",
             "threadSafe": true
+        },
+        {
+            "theme": "Dock",
+            "syntax": "DOCK MENU(&J)",
+            "threadSafe": true
         }
     ]
 }


### PR DESCRIPTION
Hi,
It's a work in progress feature (do not merge)

but maybe you have some idea (if you find interesting the feature)

# TODO

- [ ] convert parameters object options to structs (read items collection)
- [ ] convert structs to `NSMenuItem` (title, method name, etc...)
- [ ] execute 4d method on click with success (today in main thread it's do nothing)

# Technical issue

If we are out of the thread that call the plugin method (like main thread), then `PA_HasObjectProperty`(so `ob_is_defined` too) or `PA_ExecuteMethod` do not work [I see that the 4D thread have not the good context do execute 4d code]

EDIT: `PA_NewProcess` will fix that, by creating new process for 4D

# Preview

"My method" added 

![Screenshot MenuDock](https://user-images.githubusercontent.com/59135882/126901084-e76a9473-a7dd-477e-9ea7-58a990f89a5f.png)
