### PR TITLE
Add custom menu to dock

### DIFF
--- a/Dock Tile/4DPlugin-Dock-Tile.h
+++ b/Dock Tile/4DPlugin-Dock-Tile.h
@@ -12,7 +12,6 @@
 #define PLUGIN_DOCK_TILE_H
 
 #include "4DPluginAPI.h"
-#include "C_TEXT.h"
 #import <Cocoa/Cocoa.h>
 
 #pragma mark -
@@ -26,7 +25,7 @@ void DOCK_Get_icon(PA_PluginParameters params);
 void DOCK_GET_SIZE(PA_PluginParameters params);
 void DOCK_GET_SCREEN_FRAME(PA_PluginParameters params);
 void DOCK_SET_PROGRESS(PA_PluginParameters params);
-void DOCK_MENU(PA_PluginParameters params);
+void DOCK_SET_MENU(PA_PluginParameters params);
 
 // draw progress
 

--- a/Dock Tile/Dock Tile.xcodeproj/project.pbxproj
+++ b/Dock Tile/Dock Tile.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		48B119C426ACBA10009C3433 /* 4DPlugin-JSON.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48B119C226ACBA0F009C3433 /* 4DPlugin-JSON.cpp */; };
 		48B119C526ACBA10009C3433 /* 4DPlugin-JSON.h in Headers */ = {isa = PBXBuildFile; fileRef = 48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */; };
 		48B119C726ACBA46009C3433 /* QuartzCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48B119C626ACBA46009C3433 /* QuartzCore.framework */; };
+		48FF3EA026AFCE9B00294463 /* DockMenuController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 48FF3E9E26AFCE9B00294463 /* DockMenuController.cpp */; };
+		48FF3EA126AFCE9B00294463 /* DockMenuController.h in Headers */ = {isa = PBXBuildFile; fileRef = 48FF3E9F26AFCE9B00294463 /* DockMenuController.h */; };
 		8D01CCCA0486CAD60068D4B7 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 089C167DFE841241C02AAC07 /* InfoPlist.strings */; };
 		D120937F13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h in Headers */ = {isa = PBXBuildFile; fileRef = D120937E13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h */; };
 		D130064F12F02D9700702C0E /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D130064E12F02D9700702C0E /* Cocoa.framework */; };
@@ -55,6 +57,8 @@
 		48B119C226ACBA0F009C3433 /* 4DPlugin-JSON.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = "4DPlugin-JSON.cpp"; sourceTree = "<group>"; };
 		48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "4DPlugin-JSON.h"; sourceTree = "<group>"; };
 		48B119C626ACBA46009C3433 /* QuartzCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = QuartzCore.framework; path = System/Library/Frameworks/QuartzCore.framework; sourceTree = SDKROOT; };
+		48FF3E9E26AFCE9B00294463 /* DockMenuController.cpp */ = {isa = PBXFileReference; explicitFileType = sourcecode.cpp.objcpp.preprocessed; path = DockMenuController.cpp; sourceTree = "<group>"; };
+		48FF3E9F26AFCE9B00294463 /* DockMenuController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DockMenuController.h; sourceTree = "<group>"; };
 		8D01CCD10486CAD60068D4B7 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D120937E13534DCC00A72CAA /* 4DPlugin-Dock-Tile.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "4DPlugin-Dock-Tile.h"; sourceTree = "<group>"; };
 		D130064E12F02D9700702C0E /* Cocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Cocoa.framework; path = /System/Library/Frameworks/Cocoa.framework; sourceTree = "<absolute>"; };
@@ -121,6 +125,8 @@
 				48B119C326ACBA0F009C3433 /* 4DPlugin-JSON.h */,
 				48B119BE26ACBA02009C3433 /* NSBezierPath+DockTile.cpp */,
 				48B119BF26ACBA02009C3433 /* NSBezierPath+DockTile.h */,
+				48FF3E9E26AFCE9B00294463 /* DockMenuController.cpp */,
+				48FF3E9F26AFCE9B00294463 /* DockMenuController.h */,
 				18B684ED06944F2000CC6A1E /* 4D Plugin API */,
 			);
 			name = Source;
@@ -172,6 +178,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				18B684F706944F2000CC6A1E /* 4DPluginAPI.h in Headers */,
+				48FF3EA126AFCE9B00294463 /* DockMenuController.h in Headers */,
 				18B684F806944F2000CC6A1E /* EntryPoints.h in Headers */,
 				18B684F906944F2000CC6A1E /* Flags.h in Headers */,
 				18B684FA06944F2000CC6A1E /* PrivateTypes.h in Headers */,
@@ -286,6 +293,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				18B684FF06944F8800CC6A1E /* 4DPlugin-Dock-Tile.cpp in Sources */,
+				48FF3EA026AFCE9B00294463 /* DockMenuController.cpp in Sources */,
 				D163219623EBAC2600E1FAFA /* C_TEXT.cpp in Sources */,
 				D13116A91A03ACB700DE1322 /* 4DPluginAPI.c in Sources */,
 				48B119C426ACBA10009C3433 /* 4DPlugin-JSON.cpp in Sources */,

--- a/Dock Tile/DockMenuController.cpp
+++ b/Dock Tile/DockMenuController.cpp
@@ -1,0 +1,84 @@
+//
+//  DockMenuController.cpp
+//  Dock Tile
+//
+//  Created by Eric Marchand on 27/07/2021.
+//
+
+#include "DockMenuController.h"
+#include "C_TEXT.h"
+#import <objc/objc-class.h>
+
+namespace ExecuteInProcess
+{
+    PA_Unichar* methodName;
+    void call()
+    {
+        PA_long32 methodID = PA_GetMethodID(methodName);
+        PA_Variable parameters[0];
+        PA_ExecuteMethodByID(methodID, parameters, 0);
+        // or
+        // PA_Unistring key = PA_CreateUnistring(&methodName[0]);
+        // PA_ExecuteMethod(&key);
+    }
+}
+
+@implementation DockMenuController
+
+@synthesize menu;
+
++ (id)shared
+{
+    static DockMenuController *sharedInstance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[self alloc] init];
+        sharedInstance.menu = [[NSMenu alloc] initWithTitle:@"dock app menu"];
+        [sharedInstance.menu setAutoenablesItems: NO];
+        dispatch_async(dispatch_get_main_queue(), ^{
+            Method delegateMethod = class_getInstanceMethod([sharedInstance class], @selector(applicationDockMenu:));
+            IMP imp = method_getImplementation(delegateMethod);
+            class_addMethod([[[NSApplication sharedApplication] delegate] class], @selector(applicationDockMenu:), imp, method_getTypeEncoding(delegateMethod));
+        });
+    });
+    return sharedInstance;
+}
+
+- (void) clearAll
+{
+    [menu removeAllItems];
+}
+
+- (void) add:(DockMenuItem)item
+{
+    NSMenuItem *menuItem = [[NSMenuItem alloc] initWithTitle: item.title action: @selector(menuItemAction:) keyEquivalent:@""];
+    [menuItem setEnabled: YES];
+    [menuItem setTarget: [DockMenuController shared]];
+    [menuItem setRepresentedObject: item.methodName];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [menu addItem: menuItem];
+    });
+}
+
+- (void) menuItemAction:(NSMenuItem *)sender
+{
+    NSString* methodName = [sender representedObject];
+    NSLog(@"Dock Menu Item Action %@", methodName);
+
+    // schedule it in a process that could execute 4d code
+    C_TEXT methodNameText;
+    methodNameText.setUTF16String(methodName);
+    ExecuteInProcess::methodName = const_cast<PA_Unichar*>(methodNameText.getUTF16StringPtr()); // /!\ not very safe if multiple call
+    PA_NewProcess((void *) ExecuteInProcess::call, 0, (PA_Unichar *)"$\0d$\0o\0c\0k\0m\0e\0n\0u\0");
+}
+
+- (NSMenu *)applicationDockMenu:(NSApplication *)sender
+{
+    if([[[DockMenuController shared] menu] numberOfItems]>0)
+    {
+        return [[DockMenuController shared] menu];
+    }
+    return nil;
+}
+
+@end

--- a/Dock Tile/DockMenuController.h
+++ b/Dock Tile/DockMenuController.h
@@ -1,0 +1,32 @@
+//
+//  DockMenuController.h
+//  Dock Tile
+//
+//  Created by Eric Marchand on 27/07/2021.
+//
+
+#ifndef MENU_CONTROLLER_H
+#define MENU_CONTROLLER_H
+
+#import <Cocoa/Cocoa.h>
+
+typedef struct DockMenuItem {
+    NSString* title;
+    NSString* methodName;
+} DockMenuItem;
+
+@interface DockMenuController : NSObject
+
+@property (atomic, assign) NSMenu* menu;
+
++ (id)shared;
+
+- (void) clearAll;
+- (void) add:(DockMenuItem)item;
+
+- (void) menuItemAction:(NSMenuItem *)sender;
+- (NSMenu *)applicationDockMenu:(NSApplication *)sender;
+
+@end
+
+#endif /* MENU_CONTROLLER_H */

--- a/Dock Tile/manifest.json
+++ b/Dock Tile/manifest.json
@@ -49,7 +49,7 @@
         },
         {
             "theme": "Dock",
-            "syntax": "DOCK MENU(&J)",
+            "syntax": "DOCK SET MENU(&J)",
             "threadSafe": true
         }
     ]


### PR DESCRIPTION
Follow WIP #8 (It was not finished yet)

This code will add two menu items to dock

```4d
DOCK SET MENU(New object("items"; New collection(\
  New object("title"; "TEST Method"; "methodName"; "TEST"); \
  New object("title"; "update_manifest_json"; "methodName"; "update_manifest_json")\
)))
```
to call associated 4D method defined by `methodName`

to reset just add no items
```4d
DOCK SET MENU(New object())
```

## possible enhancement

- Implement sub menu by passing "items" collection to an item (I have started it but I do not know a lot about c++, making vector, array in struct etc..)
- Make code more safe : I find a way to execute 4d code but if two call are in parallel, last one will be called two times
- We could change parameter to variant and if collection instead of object manage it as a collection of menu items